### PR TITLE
Adjust logging levels and add heartbeat summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,10 +67,18 @@ SERVICES_ALWAYS_CHECK="false"
 #    If you have apprise running separately, you may specify that host here with the path/endpoint.
 APPRISE_API_URL="http://apprise:8000/notify"
 
-# DEBUG - Every received message is logged
-# INFO  - Only notified messages are logged
+# TRACE - Full JSON payload for every received message
+# DEBUG - Per-message processing logs + all below
+# INFO  - Heartbeat summary, notifications, connection events, errors
 # ERROR - Only errors are logged
 LOG_LEVEL="INFO"
+
+# How often (in seconds) to emit the heartbeat log summary (default: 120)
+HEARTBEAT_INTERVAL=120
+
+# Timezone for log timestamps (e.g. America/Chicago, Europe/London)
+# Defaults to UTC if not set
+TIMEZONE=
 
 ### HOME ASSISTANT GATE (OPTIONAL) ###
 # Set to true to enable the Home Assistant notification gate.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Additional optional variables are in the [full environment variable reference](#
 - [Prometheus Metrics](#prometheus-metrics) — Prometheus-compatible metrics endpoint
 - [Home Assistant Gate](#home-assistant-gate) — pause notifications based on Home Assistant entity states
 - [Custom Notifications](#custom-notifications) — override the notification message and title templates
+- [Logging](#logging) — log levels, heartbeat summary, and timestamps
 
 ---
 
@@ -90,7 +91,9 @@ Additional optional variables are in the [full environment variable reference](#
 | `SERVICES`               | Comma-separated list of services for retrieving flight source/destination. Valid options: `flightaware`, `adsbdb`.                           | `flightaware`                |
 | `SERVICES_ALWAYS_CHECK`  | Retrieve source/destination for **every** message (`true`), or only when thresholds are met (`false`).                                       | `false`                      |
 | `APPRISE_API_URL`        | Apprise API URL for sending notifications.                                                                                                   | `http://apprise:8000/notify` |
-| `LOG_LEVEL`              | Logging level: `DEBUG` (all messages), `INFO` (only notifications), or `ERROR` (only errors).                                                | `INFO`                       |
+| `LOG_LEVEL`              | Logging verbosity. See [Logging](#logging) for level descriptions.                                                                            | `INFO`                       |
+| `HEARTBEAT_INTERVAL`     | How often (in seconds) to emit a log summary of messages processed and notifications sent.                                                    | `120`                        |
+| `TIMEZONE`               | Timezone for log timestamps (e.g. `America/Chicago`, `Europe/London`). Defaults to UTC.                                                       | *empty*                      |
 | `APP_SERVER_ENABLED`     | Enable the optional web dashboard (EJS + Socket.IO).                                                                                         | `false`                      |
 | `APP_PORT`               | Port for the web dashboard server.                                                                                                           | `8080`                       |
 | `METRICS_SERVER_ENABLED` | Enable the optional Prometheus metrics server.                                                                                               | `false`                      |
@@ -378,6 +381,69 @@ The title receives the same `flight` object plus an `env` key (`development` / `
 ```
 
 </details>
+
+---
+
+## Logging
+
+All log lines include a level and timestamp:
+
+```
+[INFO] [2026-06-01T14:32:01Z] TCP Socket: listening on port 30047
+[INFO] [2026-06-01T14:34:01Z] Heartbeat: 298 messages, 1 notified, 0 failed (last 120s)
+[INFO] [2026-06-01T14:34:23Z] Notified: AAL123
+[ERROR] [2026-06-01T14:35:45Z] Failed to notify for DAL456: connection refused
+```
+
+### Log Levels
+
+Set with the `LOG_LEVEL` environment variable.
+
+| Level | What you see |
+|-------|-------------|
+| `TRACE` | Everything in DEBUG plus a full JSON dump of each processed aircraft |
+| `DEBUG` | Per-message `Processing`/`Processed` logs for every received aircraft |
+| `INFO` | Heartbeat summary, successful notifications, connection events, and errors *(default)* |
+| `WARN` | Degraded-state warnings (e.g. FlightAware parse failures, HA entity fetch errors) and errors |
+| `ERROR` | Only hard errors |
+
+At the default `INFO` level, logs are quiet enough to spot errors immediately while still confirming the system is alive via the heartbeat.
+
+### Heartbeat
+
+Every `HEARTBEAT_INTERVAL` seconds (default `120`), FlightAlert logs a summary:
+
+```
+[INFO] [2026-06-01T14:34:01Z] Heartbeat: 298 messages, 1 notified, 0 failed (last 120s)
+```
+
+This tells you how many aircraft messages were processed, how many triggered notifications, and how many notification failures occurred in the last interval — without logging every individual aircraft.
+
+### Timestamps
+
+Timestamps default to UTC. Set `TIMEZONE` to a [tz database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to use local time instead:
+
+```yaml
+environment:
+  TIMEZONE: "America/Chicago"
+```
+
+```
+[INFO] [2026-06-01 09:34:01] Heartbeat: 298 messages, 1 notified, 0 failed (last 120s)
+```
+
+### Viewing Logs
+
+```bash
+# Follow live logs
+docker logs -f flightalert
+
+# Show only errors
+docker logs flightalert 2>&1 | grep '\[ERROR\]'
+
+# Show logs from the last hour
+docker logs --since 1h flightalert
+```
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@js-joda/core": "^5.6.5",
+        "@js-joda/timezone": "^2.25.1",
         "axios": "^1.9.0",
         "dotenv": "^16.5.0",
         "ejs": "^3.1.10",
@@ -462,10 +463,19 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
-      "integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.7.0.tgz",
+      "integrity": "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.25.1.tgz",
+      "integrity": "sha512-s79ts8bXrWqM9dIBKc0AdgGuAUFpu9gmzYhOCPHJlks/Sf7FSbJHRauWlFYUwjSTZevimqthEvJycrwrVz5m4g==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@js-joda/core": ">=5.7.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "description": "",
   "dependencies": {
     "@js-joda/core": "^5.6.5",
+    "@js-joda/timezone": "^2.25.1",
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "ejs": "^3.1.10",

--- a/src/flightQueue.ts
+++ b/src/flightQueue.ts
@@ -16,7 +16,7 @@ let totalFailed = 0;
 const queue = new PQueue({ concurrency: 1 });
 
 queue.on('error', error => {
-    Logger.error(error);
+    Logger.error('[Queue]', error);
     totalFailed++;
     eventEmitter.emit(FAILED_FLIGHT, totalFailed);
 });
@@ -81,7 +81,7 @@ const workFlight = async (aircraft: Record<string, any>): Promise<Aircraft> => {
         try {
             const notified = await NotificationManager.notify(aircraftModel);
             if(notified) {
-                Logger.info('Notified: ' + aircraftModel.callsign + '\n\n')
+                Logger.info('Notified: ' + aircraftModel.callsign)
                 totalNotified++;
                 aircraftModel.lastNotified = Instant.now().epochSecond();
                 if(aircraftModel?.callsign) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { jsonrepair } from 'jsonrepair'
 import net from 'net';
 import { processFlight } from './flightQueue';
 import { IService } from './services/Service';
-import eventEmitter, { PROCESSED_FLIGHT, PROCESSING_FLIGHT, RECEIVER_SETUP } from './events';
+import eventEmitter, { PROCESSED_FLIGHT, PROCESSING_FLIGHT, RECEIVER_SETUP, NOTIFIED_FLIGHT, FAILED_FLIGHT } from './events';
 import receiver from './models/receiver';
 import { Aircraft } from './models/aircraft';
 import Logger from './logger';
@@ -37,7 +37,7 @@ const processFlightData = async (
             await processFlight(flight);
         };
     } catch (e: any) {
-        Logger.error(e.message)
+        Logger.error(e)
         throw e;
     }
 }
@@ -81,8 +81,7 @@ const processWithDataFromSocket = async () => {
     });
 
     client.on('close', () => {
-        Logger.info('TCP Socket: Disconnected.');
-        Logger.info('TCP Socket: Setting up connect retry')
+        Logger.info('TCP Socket: Disconnected. Setting up retry...')
         retrying = true;
         if(retries >= maxRetries) {
             Logger.error('TCP Socket: Reached maximum connect retries: ' + maxRetries)
@@ -97,14 +96,35 @@ const processWithDataFromSocket = async () => {
 }
 
 const setupEventListeners = async () => {
+    let messageCount = 0;
+    let notificationCount = 0;
+    let failedCount = 0;
+
     eventEmitter.on(PROCESSING_FLIGHT, (data: Record<string, any>) => {
-        Logger.info('Processing: ' + data?.callsign)
+        messageCount++;
+        Logger.debug('Processing: ' + data?.callsign);
     });
 
     eventEmitter.on(PROCESSED_FLIGHT, async (flight: Aircraft) => {
-        Logger.debug(JSON.stringify(flight.toJson(true), null, 3));
-        Logger.info('Processed: ' + flight.callsign + (flight.notify ? '' : '\n\n'));
+        Logger.trace(JSON.stringify(flight.toJson(true), null, 3));
+        Logger.debug('Processed: ' + flight.callsign);
     });
+
+    eventEmitter.on(NOTIFIED_FLIGHT, () => {
+        notificationCount++;
+    });
+
+    eventEmitter.on(FAILED_FLIGHT, () => {
+        failedCount++;
+    });
+
+    const intervalSeconds = parseInt(process.env.HEARTBEAT_INTERVAL ?? '120');
+    setInterval(() => {
+        Logger.info(`Heartbeat: ${messageCount} messages, ${notificationCount} notified, ${failedCount} failed (last ${intervalSeconds}s)`);
+        messageCount = 0;
+        notificationCount = 0;
+        failedCount = 0;
+    }, intervalSeconds * 1000);
 }
 
 const setupReceiverData = async () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
+import { DateTimeFormatter, ZonedDateTime, ZoneId, ZoneOffset } from '@js-joda/core';
+import '@js-joda/timezone';
 
-
-// Use a string union type for log levels for type-safety and flexibility.
 type LogLevelName = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
 class Logger {
@@ -18,7 +18,16 @@ class Logger {
         this.minLevel = this.levels[minLevel.toUpperCase() as LogLevelName] || this.levels.INFO;
     }
 
-    // A method to handle the actual logging.
+    private getTimestamp(): string {
+        const tz = process.env.TIMEZONE;
+        if (tz) {
+            return ZonedDateTime.now(ZoneId.of(tz))
+                .format(DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss'));
+        }
+        return ZonedDateTime.now(ZoneOffset.UTC)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+    }
+
     _log(level: LogLevelName, ...messages: any[]): void {
         if (this.levels[level] >= this.minLevel) {
             const logMethod: (...args: any[]) => void = ({
@@ -29,7 +38,7 @@ class Logger {
                 ERROR: console.error,
             })[level] || console.log;
 
-            logMethod(`[${level}]`, ...messages);
+            logMethod(`[${level}] [${this.getTimestamp()}]`, ...messages);
         }
     }
 

--- a/src/models/receiver.ts
+++ b/src/models/receiver.ts
@@ -51,7 +51,7 @@ export class Receiver {
             this.receiverData = response.data as IReceiverData;
             return this.receiverData;
     } catch(e) {
-            Logger.error('Failed to get receiver information')
+            Logger.error('Failed to get receiver information from: ' + process.env.RECEIVER_HOST)
             throw e;
         }
     }
@@ -67,7 +67,7 @@ export class Receiver {
             !lat ||
             !lon
         ) {
-            Logger.info('not enough data for distance');
+            Logger.debug('not enough data for distance');
             return null;
         }
 
@@ -102,13 +102,7 @@ export class Receiver {
     }
 
     async calculateDistanceFromReceiver(lat1: number, lon1: number, lat2: number, lon2: number): Promise<number | null> {
-        if(
-            !lat1 ||
-            !lon1 ||
-            !lat2 ||
-            !lon2
-        ) {
-            Logger.info('calc: not enough data for distance');
+        if(!lat1 || !lon1 || !lat2 || !lon2) {
             return null;
         }
 

--- a/src/notifications/NotificationManager.ts
+++ b/src/notifications/NotificationManager.ts
@@ -1,6 +1,7 @@
 import { Aircraft } from '@/models/aircraft';
 import axios from 'axios';
 import Template from './Template';
+import Logger from '@/logger';
 
 class NotificationManager {
     public templates: Record<string, Template> = {};
@@ -37,6 +38,8 @@ class NotificationManager {
             body: renderedBodyTemplate.trim(),
             type: 'info',
         };
+
+        Logger.debug('[Notification] Sending: ' + aircraft.callsign + ' → ' + process.env.APPRISE_API_URL);
 
         await axios.post(
             process.env.APPRISE_API_URL,

--- a/src/services/AdsbDb.ts
+++ b/src/services/AdsbDb.ts
@@ -87,6 +87,7 @@ export class AdsbDb implements IService {
             /* @ts-ignore */
             return response.data.response as Record<string, any>;
         } catch (e: any) {
+            Logger.error(`[AdsbDb] Failed to get route for ${callsign} (${hex}): ` + (e?.message ?? e));
             return null;
         }
     }
@@ -96,8 +97,8 @@ export class AdsbDb implements IService {
             const response = await axios.get('https://api.adsbdb.com/v0/aircraft/' + hex);
             /* @ts-ignore */
             return response.data.response.aircraft;
-        } catch (e) {
-            Logger.error('Failed to get aircraft information from ADSB DB.');
+        } catch (e: any) {
+            Logger.error(`[AdsbDb] Failed to get aircraft info for ${hex}: ` + (e?.message ?? e));
             throw e;
         }
     }

--- a/src/services/FlightAware.ts
+++ b/src/services/FlightAware.ts
@@ -1,6 +1,7 @@
 import storage from 'node-persist';
 import { ChronoUnit, Instant, LocalDateTime } from '@js-joda/core'
 import { IService } from './Service';
+import Logger from '../logger';
 
 export interface IFlightAwareCacheReturn {
     useCache: boolean
@@ -90,18 +91,25 @@ export class FlightAware implements IService {
 
         const pullFromCache = await this.pullFromCacheForFlightAware(flightAwareCache, callsign);
         if(pullFromCache?.useCache) {
+            Logger.debug(`[FlightAware] Cache hit for ${callsign}`);
             return {
-
                 useCache: pullFromCache.useCache,
                 flightAwareFlight: pullFromCache.flightAwareFlight
             };
         }
 
-        const response = await fetch('https://www.flightaware.com/live/flight/' + callsign);
-        const data = await response.text();
+        let data: string;
+        try {
+            const response = await fetch('https://www.flightaware.com/live/flight/' + callsign);
+            data = await response.text();
+        } catch (e: any) {
+            Logger.error(`[FlightAware] HTTP fetch failed for ${callsign}: ` + (e?.message ?? e));
+            return { flightAwareFlight: null, error: e?.message ?? 'fetch failed' };
+        }
 
         const variableMatch = data.match(/var trackpollBootstrap = (\{.*?\});/);
         if(!variableMatch) {
+            Logger.warn(`[FlightAware] Could not parse response for ${callsign} — page structure may have changed`);
             return {
                 flightAwareFlight: null,
                 error: 'No variable match from FlightAware.'
@@ -112,6 +120,7 @@ export class FlightAware implements IService {
         const flightAwareResults = JSON.parse(variableString);
 
         if(!flightAwareResults || !flightAwareResults?.flights) {
+            Logger.warn(`[FlightAware] No flights object in response for ${callsign}`);
             return {
                 error: 'No flightAwareResults.',
                 flightAwareFlight: null,
@@ -120,6 +129,7 @@ export class FlightAware implements IService {
 
         const firstFlight = Object.keys(flightAwareResults.flights)[0] ?? null
         if(!firstFlight) {
+            Logger.debug(`[FlightAware] No flight entries for ${callsign}`);
             return {
                 error: 'No flights from FlightAware.',
                 flightAwareFlight: null,


### PR DESCRIPTION
Demote per-message logs to DEBUG/TRACE and add a periodic heartbeat summary at INFO so logs stay quiet while still confirming liveness. Add timestamps (with optional TIMEZONE) and more specific error messages across services.